### PR TITLE
psi test + typing

### DIFF
--- a/probfit/weaklabels.py
+++ b/probfit/weaklabels.py
@@ -1,4 +1,4 @@
-from typing import Union, Type, Tuple, List, Sequence, Any
+from typing import Union, Type, Tuple, List, Sequence, Any, Optional
 
 import numpy as np
 from iminuit.util import make_func_code, describe


### PR DESCRIPTION
- added the `psi` test (similar to gtest, in decibels) 
- Static typing is better to use then hard assertions here. `assert isinstance(binned_data, BinnedLabels)` gave namespace issues in the notebook. From a software engineering perspective: static typing simplifies the function code and improves performance on runtime.
- `__repr__ ` was handy when printing (a sequence of) types in the notebook.